### PR TITLE
corrigindo bug que criava erro no SQL vindo do servidor

### DIFF
--- a/src/main/java/br/org/cria/splinkerapp/services/implementations/DataSetService.java
+++ b/src/main/java/br/org/cria/splinkerapp/services/implementations/DataSetService.java
@@ -200,7 +200,8 @@ public class DataSetService extends BaseRepository {
     {
         var normalizedToken = StringStandards.normalizeString(token);
         var fileName = "%s/%s_sql_command.sql".formatted(System.getProperty("user.dir"), normalizedToken);
-        String read = String.join("",Files.readAllLines(Path.of(fileName)));
+        var lines = Files.readAllLines(Path.of(fileName));
+        String read = String.join(" ", lines);
         return read;
     }
 


### PR DESCRIPTION
### Bug no SQL

**Problema**
Havia um erro no parsing do SQL que eventualmente gerava erros na hora da geração do arquivo DWA. O comando SQL trazido do servidor era montado de maneira que o arquivo SQL local apresentava problemas na leitura caso tivesse espaço.

**Solução**
Trocar o String.join("") para String.join(" ") (caractere vazio por espaço) resolveu o problema.