### PR TITLE
Criando arquivo a partir de um workbookfactory

### DIFF
--- a/src/main/java/br/org/cria/splinkerapp/parsers/ExcelFileParser.java
+++ b/src/main/java/br/org/cria/splinkerapp/parsers/ExcelFileParser.java
@@ -1,13 +1,13 @@
 package br.org.cria.splinkerapp.parsers;
 
-import java.io.FileInputStream;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Workbook;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
 import br.org.cria.splinkerapp.utils.StringStandards;
 
 public class ExcelFileParser extends FileParser {
@@ -16,7 +16,7 @@ public class ExcelFileParser extends FileParser {
 
     public ExcelFileParser(String fileSourcePath) throws Exception {
         this.fileSourcePath = fileSourcePath;
-        workbook = new XSSFWorkbook(new FileInputStream(fileSourcePath));
+        workbook = WorkbookFactory.create(new File(fileSourcePath));
     }
 
     @Override


### PR DESCRIPTION
### Problema
O spLinker lê arquivos XLSX normalmente, porém apresenta erro ao ler arquivos XLS(Excel 2007 e versões anteriores).

### Diagnóstico
A classe utilizada para ler os arquivos Excel é uma classe específica para arquivos XLSX, capaz de ler arquivos XLS escritos apenas por versões mais recentes do Excel, que já utilizam XLSX.

### Solução
 O uso do método estático `create` da classe `WorkbookFactory`, que decide qual leitor utilizar e retorna sempe um Workbook.