### PR TITLE
corrige erro de caminho nulo quando a fonte de dados é remota

### DIFF
--- a/src/main/java/br/org/cria/splinkerapp/App.java
+++ b/src/main/java/br/org/cria/splinkerapp/App.java
@@ -258,14 +258,16 @@ public class App {
 
             DataSet ds = DataSetService.getDataSet(token);
 
-            ApplicationLog.info("Starting data import. Please wait...");
-            FileSourceManager fileSourceManager = new FileSourceManager(ds);
-            fileSourceManager.importData(
-                    SQLiteTableExtractor.extrairTabelas(
-                            DataSetService.getSQLCommandFromApi(ds.getToken())
-                    )
-            );
-            ApplicationLog.info("Import finished");
+            if (ds.isFile() || ds.isAccessDb()) {
+                ApplicationLog.info("Starting data import. Please wait...");
+                FileSourceManager fileSourceManager = new FileSourceManager(ds);
+                fileSourceManager.importData(
+                        SQLiteTableExtractor.extrairTabelas(
+                                DataSetService.getSQLCommandFromApi(ds.getToken())
+                        )
+                );
+                ApplicationLog.info("Import finished");
+            }
 
             DarwinCoreArchiveService service = new DarwinCoreArchiveService(ds);
             service.readDataFromSource()


### PR DESCRIPTION
## Problema
Ao executar o splinker.jar via linha de comando com uma coleção do tipo PostgreSQL (ou qualquer outra fonte SQL — MySQL, SQLServer, Oracle), o processo falhava com o seguinte erro:

Cannot invoke "String.toLowerCase()" because the return value of
"br.org.cria.splinkerapp.models.DataSet.getDataSetFilePath()" is null
Para fontes SQL, o campo dataSourceFilePath nunca é preenchido — apenas as credenciais de banco (host, porta, usuário, senha etc.) são armazenadas, causando o NullPointerException ao tentar chamar .toLowerCase() sobre o caminho nulo.

```plain
$ java -jar splinker.jar splinker.conf 
                WELCOME TO SPLINK                 
Starting transmission process
==========================================
Processing token: ---
Type: PostgreSQL
Collection: ---
Starting data import. Please wait...
Error processing token ---: Cannot invoke "String.toLowerCase()" because the return value of "br.org.cria.splinkerapp.models.DataSet.getDataSetFilePath()" is null
==========================================
Processing finished.
Total processed: 1
Success: 0
Failed: 1
Ignored: 0
```

## Solução
App.java - adicionado verificação `ds.isFile() || ds.isAccessDb()` ao redor do bloco de importação via FileSourceManager, espelhando o comportamento já existente na interface gráfica. Para fontes SQL, o fluxo segue diretamente para o DarwinCoreArchiveService, que se conecta via JDBC sem necessitar de caminho de arquivo.